### PR TITLE
just publish the src directory, no need to copy the output

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "repository": "https://github.com/ourzora/protocol-rewards.git",
   "license": "MIT",
   "files": [
-    "dist/"
+    "src/"
   ],
   "scripts": {
-    "prepack": "mkdir -p dist && cp -r src/ dist/contracts && cp -r out/ dist/artifacts/",
     "prettier:check": "prettier --check 'src/**/*.sol' 'test/**/*.sol' 'script/**/*.sol'",
     "prettier": "prettier --write 'src/**/*.sol' 'test/**/*.sol' 'script/**/*.sol'"
   },


### PR DESCRIPTION
We can just have npm include the `src` directory, instead of needing to copy it to the `dist` folder.

This also allows the contracts to be imported like:

`import {IProtocolRewards} from "@zoralabs/protocol-rewards/src/contracts/interfaces/IProtocolRewards.sol";`